### PR TITLE
Security fixes, better search, map labels, business hours, and seed resources

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -26,6 +26,10 @@ jobs:
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
       UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
       UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+      # session-edge.ts throws at import time when JWT_SECRET is missing, which
+      # breaks `next build` during page-data collection. CI only compiles the
+      # app - it never signs real sessions - so a build-only fallback is safe.
+      JWT_SECRET: ${{ secrets.JWT_SECRET || 'codeql-build-only-secret-0123456789abcdef' }}
     permissions:
       actions: read
       contents: read

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -151,10 +151,99 @@ async function main() {
       description: 'Consulate General of Nepal in New York City.',
       status: 'APPROVED',
       categoryId: legalCategory.id,
+      openDays: 'Mon,Tue,Wed,Thu,Fri',
+      openTime: new Date('1970-01-01T09:30:00Z'),
+      closeTime: new Date('1970-01-01T17:00:00Z'),
       Location: {
         create: {
           latitude: 40.7519151,
           longitude: -73.9744031,
+        },
+      },
+    },
+  });
+
+  // openTime/closeTime are stored as time-of-day (Postgres `time`), so seed
+  // them as 1970-01-01 UTC dates - only the clock portion is persisted.
+  await prisma.resource.create({
+    data: {
+      name: 'The Tibet Fund',
+      address: '241 E 32nd St, New York, NY 10016',
+      city: 'Manhattan',
+      description:
+        'Nonprofit supporting Tibetan communities through education, health, and cultural preservation programs.',
+      status: 'APPROVED',
+      categoryId: communityCategory.id,
+      openDays: 'Mon,Tue,Wed,Thu,Fri',
+      openTime: new Date('1970-01-01T09:00:00Z'),
+      closeTime: new Date('1970-01-01T17:00:00Z'),
+      Location: {
+        create: {
+          latitude: 40.7443,
+          longitude: -73.9787,
+        },
+      },
+    },
+  });
+
+  await prisma.resource.create({
+    data: {
+      name: 'Tibet House US',
+      address: '22 W 15th St, New York, NY 10011',
+      city: 'Manhattan',
+      description:
+        'Cultural center dedicated to preserving Tibetan culture through exhibitions, classes, and public programs.',
+      status: 'APPROVED',
+      categoryId: educationCategory.id,
+      openDays: 'Mon,Tue,Wed,Thu,Fri',
+      openTime: new Date('1970-01-01T11:00:00Z'),
+      closeTime: new Date('1970-01-01T17:00:00Z'),
+      Location: {
+        create: {
+          latitude: 40.7374,
+          longitude: -73.9939,
+        },
+      },
+    },
+  });
+
+  await prisma.resource.create({
+    data: {
+      name: 'Queens Public Library - Woodside',
+      address: '54-22 Skillman Ave, Woodside, NY 11377',
+      city: 'Queens',
+      description:
+        'Neighborhood library branch with free ESOL classes, citizenship resources, and multilingual services.',
+      status: 'APPROVED',
+      categoryId: educationCategory.id,
+      openDays: 'Mon,Tue,Wed,Thu,Fri,Sat',
+      openTime: new Date('1970-01-01T10:00:00Z'),
+      closeTime: new Date('1970-01-01T18:00:00Z'),
+      Location: {
+        create: {
+          latitude: 40.7471,
+          longitude: -73.9063,
+        },
+      },
+    },
+  });
+
+  await prisma.resource.create({
+    data: {
+      name: 'NYC Health + Hospitals / Elmhurst',
+      address: '79-01 Broadway, Elmhurst, NY 11373',
+      city: 'Queens',
+      description:
+        'Public hospital serving the Elmhurst and Jackson Heights communities, with interpretation services available.',
+      status: 'APPROVED',
+      categoryId: healthCategory.id,
+      openDays: 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
+      openTime: new Date('1970-01-01T00:00:00Z'),
+      closeTime: new Date('1970-01-01T23:59:00Z'),
+      Location: {
+        create: {
+          latitude: 40.7445,
+          longitude: -73.8861,
         },
       },
     },

--- a/src/app/api/auth/forgotpassword/route.ts
+++ b/src/app/api/auth/forgotpassword/route.ts
@@ -1,15 +1,13 @@
 
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest, NextResponse, after } from "next/server"
 import { prisma } from '@/app/lib/prisma'
 import { sendEmail } from "@/app/lib/helpers/mailer"
-import { checkRateLimit } from "@/app/lib/rate-limit"
+import { checkRateLimit, getClientIp } from "@/app/lib/rate-limit"
 
 // backend generates a token, stores in db and sends email with token using nodemailer
 export async function POST(request: NextRequest) {
     try {
-        // Get client IP from request headers
-        const forwardedFor = request.headers.get('x-forwarded-for')
-        const ip = forwardedFor?.split(',')[0] || request.headers.get('x-real-ip') || 'unknown'
+        const ip = getClientIp(request.headers)
 
         // Check rate limit
         const rateLimitResult = await checkRateLimit(ip)
@@ -28,13 +26,15 @@ export async function POST(request: NextRequest) {
             select: { id: true },
         });
 
-        // helper function sendEmail handles creating token and updating db
+        // Send after the response goes out (rather than awaiting here) so a
+        // real account and a nonexistent one take the same time to respond -
+        // otherwise the email round-trip would leak account existence via timing.
         if (user) {
-            await sendEmail({
-                email,
-                emailType: "RESET",
-                userId: user.id
-            })
+            after(() =>
+                sendEmail({ email, emailType: "RESET", userId: user.id }).catch((err) => {
+                    console.error("Failed to send reset email:", err);
+                })
+            );
         }
 
         // Respond identically whether or not the account exists, so this

--- a/src/app/api/auth/forgotpassword/route.ts
+++ b/src/app/api/auth/forgotpassword/route.ts
@@ -2,43 +2,48 @@
 import { NextRequest, NextResponse } from "next/server"
 import { prisma } from '@/app/lib/prisma'
 import { sendEmail } from "@/app/lib/helpers/mailer"
+import { checkRateLimit } from "@/app/lib/rate-limit"
 
-// backend generates a token, stores in db and sends email with token using nodemailer 
+// backend generates a token, stores in db and sends email with token using nodemailer
 export async function POST(request: NextRequest) {
     try {
+        // Get client IP from request headers
+        const forwardedFor = request.headers.get('x-forwarded-for')
+        const ip = forwardedFor?.split(',')[0] || request.headers.get('x-real-ip') || 'unknown'
+
+        // Check rate limit
+        const rateLimitResult = await checkRateLimit(ip)
+        if (rateLimitResult) return rateLimitResult
+
         const reqBody = await request.json()
         const { email } = reqBody
-        console.log(email);
         if (!email) {
             return NextResponse.json({ error: "Email is required" }, { status: 400 });
         }
 
-        // create validation if user exists
+        // Look up only the id - never return the full user record, which
+        // would include the password hash and reset/verify tokens.
         const user = await prisma.user.findUnique({
-            where: {
-                email: email
-            }
+            where: { email },
+            select: { id: true },
         });
 
-        if (!user) {
-            return NextResponse.json({ error: "Account with this email does not exist." }, { status: 404 });
+        // helper function sendEmail handles creating token and updating db
+        if (user) {
+            await sendEmail({
+                email,
+                emailType: "RESET",
+                userId: user.id
+            })
         }
-        // If yes, use nodemailer to send token to the email and 
-        // also send the token to the database
 
-         // helper function sendEmail handles creating token and updating db
-         await sendEmail({
-            email,
-            emailType: "RESET",
-            userId: user.id
-        })
-        
+        // Respond identically whether or not the account exists, so this
+        // endpoint can't be used to enumerate registered emails.
         return NextResponse.json({
-            message: "Check your email for reset password",
+            message: "If an account with that email exists, you'll receive a password reset link shortly.",
             success: true,
-            user
         })
-        
+
     } catch (error: unknown) {
         return NextResponse.json({ error: (error as Error).message }, { status: 500 });
     }

--- a/src/app/api/auth/resetpassword/route.ts
+++ b/src/app/api/auth/resetpassword/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
+import crypto from "crypto";
 import { prisma } from '@/app/lib/prisma';
 import { checkRateLimit } from "@/app/lib/rate-limit";
 //import { checkRateLimit } from '@vercel/firewall';
@@ -29,16 +30,19 @@ export async function POST(request: NextRequest) {
         // continue
         const reqBody = await request.json();
         const { token, password } = reqBody;
-        console.log("Token received: ", token);
-        
+
         if (!token || !password) {
             return NextResponse.json({ error: "Token and password are required." }, { status: 400 });
         }
 
+        // The DB only stores a SHA-256 hash of the token, so hash the incoming
+        // raw token before looking it up.
+        const hashedToken = crypto.createHash("sha256").update(token).digest("hex");
+
         // validate token and find the user
         const user = await prisma.user.findFirst({
             where: {
-                forgotPasswordToken: token,
+                forgotPasswordToken: hashedToken,
                 forgotPasswordTokenExpiry: {
                     gt: new Date()
                 }

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -1,9 +1,23 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import crypto from 'crypto';
 
 export async function GET(request: NextRequest) {
-    const authHeader = request.headers.get('authorization');
-    if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    const cronSecret = process.env.CRON_SECRET;
+    const authHeader = request.headers.get('authorization') ?? '';
+
+    if (!cronSecret) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const expected = Buffer.from(`Bearer ${cronSecret}`);
+    const provided = Buffer.from(authHeader);
+
+    const isValid =
+        expected.length === provided.length &&
+        crypto.timingSafeEqual(expected, provided);
+
+    if (!isValid) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     return NextResponse.json({ ok: true });

--- a/src/app/api/resources/edit/[id]/route.ts
+++ b/src/app/api/resources/edit/[id]/route.ts
@@ -73,9 +73,14 @@ export async function PATCH(
   try {
     const params = await props.params;
     const resourceId = parseInt(params.id, 10);
-    
+
     if (isNaN(resourceId)) {
       return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+    }
+
+    const session = await getSession();
+    if (!session || !session.userId || session.role !== Role.ADMIN) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     const body = await req.json();

--- a/src/app/api/resources/route.ts
+++ b/src/app/api/resources/route.ts
@@ -101,10 +101,40 @@ export async function POST(request: NextRequest) {
         }
 
         const body = await request.json();
+        const {
+            name,
+            description,
+            address,
+            city,
+            openDays,
+            openTime,
+            closeTime,
+            phone,
+            imageUrl,
+            facebookLink,
+            email,
+            url,
+            categoryId,
+        } = body;
+
+        // Only accept fields a submitter should control - status/rating/id
+        // etc. are set by the system (status defaults to PENDING moderation).
         const resource = await prisma.resource.create({
             data: {
-                ...body,
-                userId: Number(session.userId),
+                name,
+                description,
+                address,
+                city,
+                openDays,
+                openTime: openTime ? new Date(openTime) : null,
+                closeTime: closeTime ? new Date(closeTime) : null,
+                phone,
+                imageUrl,
+                facebookLink,
+                email,
+                url,
+                categoryId,
+                createdById: Number(session.userId),
             },
         });
 

--- a/src/app/api/resources/route.ts
+++ b/src/app/api/resources/route.ts
@@ -117,6 +117,21 @@ export async function POST(request: NextRequest) {
             categoryId,
         } = body;
 
+        if (typeof name !== "string" || !name.trim() || typeof address !== "string" || !address.trim()) {
+            return NextResponse.json(
+                { error: "name and address are required" },
+                { status: 400 }
+            );
+        }
+
+        let parsedCategoryId: number | null = null;
+        if (categoryId !== undefined && categoryId !== null) {
+            parsedCategoryId = Number(categoryId);
+            if (!Number.isInteger(parsedCategoryId)) {
+                return NextResponse.json({ error: "Invalid categoryId" }, { status: 400 });
+            }
+        }
+
         // Only accept fields a submitter should control - status/rating/id
         // etc. are set by the system (status defaults to PENDING moderation).
         const resource = await prisma.resource.create({
@@ -133,7 +148,7 @@ export async function POST(request: NextRequest) {
                 facebookLink,
                 email,
                 url,
-                categoryId,
+                categoryId: parsedCategoryId,
                 createdById: Number(session.userId),
             },
         });

--- a/src/app/api/sign-image/route.ts
+++ b/src/app/api/sign-image/route.ts
@@ -1,23 +1,54 @@
 import { v2 as cloudinary } from 'cloudinary';
-export const dynamic = 'force-dynamic';  
+import { getSession } from '@/app/lib/auth-session';
+
+export const dynamic = 'force-dynamic';
 
 cloudinary.config({
     cloud_name: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME,
     api_key: process.env.CLOUDINARY_API_KEY,
     api_secret: process.env.CLOUDINARY_API_SECRET,
   });
-   
+
+// Params that could be used to overwrite/target existing assets or change
+// how Cloudinary treats the upload - never sign these, regardless of what
+// the caller asks for.
+const DISALLOWED_PARAM_KEYS = [
+    'public_id',
+    'overwrite',
+    'invalidate',
+    'type',
+    'access_mode',
+    'moderation',
+    'eager',
+    'notification_url',
+    'resource_type',
+    'backup',
+];
 
 export async function POST(request: Request) {
+    const session = await getSession();
+    if (!session?.userId) {
+        return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
 
     const body = await request.json();
     const { paramsToSign } = body;
-   
+
+    if (!paramsToSign || typeof paramsToSign !== 'object') {
+        return Response.json({ error: 'Invalid request' }, { status: 400 });
+    }
+
+    for (const key of DISALLOWED_PARAM_KEYS) {
+        if (key in paramsToSign) {
+            return Response.json({ error: `Param "${key}" is not allowed` }, { status: 400 });
+        }
+    }
+
     if (!process.env.CLOUDINARY_API_SECRET) {
         throw new Error('CLOUDINARY_API_SECRET is not defined');
     }
-    
+
     const signature = cloudinary.utils.api_sign_request(paramsToSign, process.env.CLOUDINARY_API_SECRET);
-    
+
     return Response.json({ signature });
 }

--- a/src/app/api/sign-image/route.ts
+++ b/src/app/api/sign-image/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
     const body = await request.json();
     const { paramsToSign } = body;
 
-    if (!paramsToSign || typeof paramsToSign !== 'object') {
+    if (!paramsToSign || typeof paramsToSign !== 'object' || Array.isArray(paramsToSign)) {
         return Response.json({ error: 'Invalid request' }, { status: 400 });
     }
 

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 // import cloudinary from "cloudinary";
 import { v2 as cloudinary } from "cloudinary";
 import { checkRateLimit } from "@/app/lib/rate-limit";
+import { getSession } from "@/app/lib/auth-session";
 
 export const dynamic = 'force-dynamic';  
 
@@ -27,6 +28,11 @@ export async function POST(req: NextRequest) {
     // Check rate limit
     const rateLimitResult = await checkRateLimit(ip)
     if (rateLimitResult) return rateLimitResult
+
+    const session = await getSession();
+    if (!session?.userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
 
     const data = await req.json();
     const file = data.image; // Base64 image string

--- a/src/app/components/features/ResourceDetailCommon/Overview.tsx
+++ b/src/app/components/features/ResourceDetailCommon/Overview.tsx
@@ -1,13 +1,13 @@
 import ResourceActions from "./ResourceActions";
 import { formatOpenDays } from "@/app/lib/helpers/formatOpenDays";
+import {
+  formatTimeRange,
+  getOpenStatus,
+} from "@/app/lib/helpers/formatHours";
 import toast from "react-hot-toast";
 
 import { type Resource, User } from "@/app/lib/types";
 import { useRouter } from "next/navigation";
-
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-dayjs.extend(utc);
 
 interface OverviewTabProps {
   resource: Resource;
@@ -25,7 +25,15 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({
   router,
   // liked,
   // toggleFavorite,
-}) => (
+}) => {
+  const hours = formatTimeRange(resource.openTime, resource.closeTime);
+  const openStatus = getOpenStatus(
+    resource.openDays,
+    resource.openTime,
+    resource.closeTime
+  );
+
+  return (
   <div>
     <ResourceActions
       resource={resource}
@@ -42,15 +50,32 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({
     )}
     {resource.openDays && (
       <p>
-        <span className="font-medium">Opens:</span>{" "}
+        <span className="font-medium">Open:</span>{" "}
         {formatOpenDays(resource.openDays || null)}
+        {hours ? `, ${hours}` : ""}
       </p>
     )}
-    {resource.openTime && resource.closeTime && (
+    {!resource.openDays && hours && (
       <p>
-        <span className="font-medium">Business Hours:</span>{" "}
-        {dayjs.utc(resource.openTime).format("hh:mm A")} -{" "}
-        {dayjs.utc(resource.closeTime).format("hh:mm A")}
+        <span className="font-medium">Hours:</span> {hours}
+      </p>
+    )}
+    {openStatus && (
+      <p>
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-semibold ${
+            openStatus.isOpen
+              ? "bg-green-100 text-green-700"
+              : "bg-red-100 text-red-700"
+          }`}
+        >
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${
+              openStatus.isOpen ? "bg-green-600" : "bg-red-600"
+            }`}
+          />
+          {openStatus.label}
+        </span>
       </p>
     )}
     {resource.url && (
@@ -97,4 +122,5 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({
       </button>
     </div>
   </div>
-);
+  );
+};

--- a/src/app/lib/auth.ts
+++ b/src/app/lib/auth.ts
@@ -15,15 +15,15 @@ import { createSession, deleteSession } from "@/app/lib/session";
 import bcrypt from "bcryptjs";
 import crypto from "crypto";
 import { headers } from "next/headers";
+import { after } from "next/server";
 import { prisma } from "@/app/lib/prisma";
 import { Role } from "@prisma/client";
 import { sendEmail } from "@/app/lib/helpers/mailer";
-import { checkRateLimit } from "@/app/lib/rate-limit";
+import { checkRateLimit, getClientIp } from "@/app/lib/rate-limit";
 
 async function getRequestIp() {
   const headersList = await headers();
-  const forwardedFor = headersList.get("x-forwarded-for");
-  return forwardedFor?.split(",")[0] || headersList.get("x-real-ip") || "unknown";
+  return getClientIp(headersList);
 }
 
 // cookie should be set on the server to prevent client side tampering
@@ -163,7 +163,7 @@ export async function login(prevState: LoginFormState, formData: FormData) {
     // generic message for both "no such account" and "wrong password".
     const validPassword = await bcrypt.compare(
       password,
-      user?.password ?? "$2a$10$invalidsaltinvalidsaltinvalidsalte"
+      user?.password ?? "$2b$10$SivJBKGRRn1C27z9MOyLzuz1IOP.HW4EU.ggVVN/DOZ7FgsK1TYIe"
     );
     if (!user?.id || !validPassword) {
       return {
@@ -258,13 +258,15 @@ export async function forgotPassword(prevState: ForgotFormState, formData: FormD
       select: { id: true },
     });
 
-    // helper function sendEmail handles creating token and updating db
+    // Send after the response goes out (rather than awaiting here) so a real
+    // account and a nonexistent one take the same time to respond - otherwise
+    // the email round-trip would leak account existence via timing.
     if (user) {
-      await sendEmail({
-        email,
-        emailType: "RESET",
-        userId: user.id
-      })
+      after(() =>
+        sendEmail({ email, emailType: "RESET", userId: user.id }).catch((err) => {
+          console.error("Failed to send reset email:", err);
+        })
+      );
     }
 
     // Respond identically whether or not the account exists, so this
@@ -313,6 +315,13 @@ export async function resetPassword(prevState: ResetPasswordFormState, formData:
     if (password !== confirmPassword) {
       return {
         message: "Passwords do not match",
+        status: 400,
+      };
+    }
+
+    if (!token || typeof token !== "string") {
+      return {
+        message: "Invalid or expired token",
         status: 400,
       };
     }

--- a/src/app/lib/auth.ts
+++ b/src/app/lib/auth.ts
@@ -13,9 +13,18 @@ import {
 
 import { createSession, deleteSession } from "@/app/lib/session";
 import bcrypt from "bcryptjs";
+import crypto from "crypto";
+import { headers } from "next/headers";
 import { prisma } from "@/app/lib/prisma";
 import { Role } from "@prisma/client";
 import { sendEmail } from "@/app/lib/helpers/mailer";
+import { checkRateLimit } from "@/app/lib/rate-limit";
+
+async function getRequestIp() {
+  const headersList = await headers();
+  const forwardedFor = headersList.get("x-forwarded-for");
+  return forwardedFor?.split(",")[0] || headersList.get("x-real-ip") || "unknown";
+}
 
 // cookie should be set on the server to prevent client side tampering
 
@@ -121,6 +130,11 @@ export async function login(prevState: LoginFormState, formData: FormData) {
   }
 
   try {
+    const rateLimited = await checkRateLimit(await getRequestIp());
+    if (rateLimited) {
+      return { message: "Too many attempts. Please try again shortly.", status: 429 };
+    }
+
     const { email, password } = validatedFields.data;
 
     // Get user with minimal data needed
@@ -136,26 +150,24 @@ export async function login(prevState: LoginFormState, formData: FormData) {
       },
     });
 
-    if (!user?.id) {
-      return {
-        message: "Invalid email or user does not exist",
-        status: 401,
-      };
-    }
-
     // Check if user signed up via OAuth only (no password set)
-    if (!user.password) {
+    if (user && !user.password) {
       return {
         message: "This account uses Google sign-in. Please use the 'Sign in with Google' button.",
         status: 401,
       };
     }
 
-    // Verify password
-    const validPassword = await bcrypt.compare(password, user.password);
-    if (!validPassword) {
+    // Verify password. Compare against a dummy hash when the user doesn't
+    // exist so response timing doesn't reveal account existence, and use one
+    // generic message for both "no such account" and "wrong password".
+    const validPassword = await bcrypt.compare(
+      password,
+      user?.password ?? "$2a$10$invalidsaltinvalidsaltinvalidsalte"
+    );
+    if (!user?.id || !validPassword) {
       return {
-        message: "Password is incorrect",
+        message: "Invalid email or password",
         status: 401,
       };
     }
@@ -221,43 +233,45 @@ export async function forgotPassword(prevState: ForgotFormState, formData: FormD
       message: undefined,
       email: undefined,
       success: undefined,
-      user: undefined,
       status: undefined,
     };
   }
 
   try {
-    const { email } = validateFields.data;
-
-    const user = await prisma.user.findUnique({
-      where: {
-        email: email
-      }
-    });
-
-    if (!user) {
+    const rateLimited = await checkRateLimit(await getRequestIp());
+    if (rateLimited) {
       return {
-        message: "Account with this email does not exist. ",
-        status: 404,
+        message: "Too many attempts. Please try again shortly.",
+        status: 429,
         errors: undefined,
         email: undefined,
         success: undefined,
-        user: undefined,
-      }
+      };
     }
-    // If yes, use nodemailer to send token to the email and 
-    // also send the token to the database
+
+    const { email } = validateFields.data;
+
+    // Look up only the id - never return the full user record, which
+    // would include the password hash and reset/verify tokens.
+    const user = await prisma.user.findUnique({
+      where: { email },
+      select: { id: true },
+    });
 
     // helper function sendEmail handles creating token and updating db
-    await sendEmail({
-      email,
-      emailType: "RESET",
-      userId: user.id
-    })
+    if (user) {
+      await sendEmail({
+        email,
+        emailType: "RESET",
+        userId: user.id
+      })
+    }
+
+    // Respond identically whether or not the account exists, so this
+    // endpoint can't be used to enumerate registered emails.
     return {
-      message: "Check your email for reset password",
+      message: "If an account with that email exists, you'll receive a password reset link shortly.",
       success: true,
-      user,
       errors: undefined,
       email: undefined,
       status: undefined,
@@ -272,7 +286,6 @@ export async function forgotPassword(prevState: ForgotFormState, formData: FormD
       errors: undefined,
       email: undefined,
       success: undefined,
-      user: undefined,
     }
 
   }
@@ -304,10 +317,13 @@ export async function resetPassword(prevState: ResetPasswordFormState, formData:
       };
     }
 
+    // The DB only stores a SHA-256 hash of the token, so hash the incoming
+    // raw token before looking it up.
+    const hashedToken = crypto.createHash("sha256").update(token).digest("hex");
+
     const user = await prisma.user.findFirst({
       where: {
-        // forgotPasswordToken: hashedToken,
-        forgotPasswordToken: token,
+        forgotPasswordToken: hashedToken,
         forgotPasswordTokenExpiry: {
           gt: new Date()
         }

--- a/src/app/lib/forms/definitions.ts
+++ b/src/app/lib/forms/definitions.ts
@@ -124,14 +124,8 @@ export type ForgotFormState =
     message?: string
     email?: string
     success?: boolean
-    user?: {
-      id: number;
-      email: string;
-      firstName?: string;
-      lastName?: string;
-    }
     status?: number
-  } 
+  }
 | undefined
 
 export type ResetPasswordFormState =

--- a/src/app/lib/helpers/__tests__/formatHours.test.ts
+++ b/src/app/lib/helpers/__tests__/formatHours.test.ts
@@ -1,0 +1,65 @@
+// Import Jest globals explicitly so TS doesn't resolve `expect` to the
+// Cypress/chai types that are also in this project.
+import { describe, expect, it } from "@jest/globals";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+import { formatTimeRange, getOpenStatus } from "../formatHours";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+// Times are stored as time-of-day pinned to 1970-01-01 UTC.
+const t = (time: string) => `1970-01-01T${time}:00.000Z`;
+
+// Build a "now" at a given New York wall-clock time. 2026-07-06 is a Monday.
+const nyNow = (dateTime: string) => dayjs.tz(dateTime, "America/New_York");
+
+describe("formatTimeRange", () => {
+  it("formats a standard range", () => {
+    expect(formatTimeRange(t("09:00"), t("17:30"))).toBe("9 AM – 5:30 PM");
+  });
+
+  it("handles noon and midnight", () => {
+    expect(formatTimeRange(t("00:00"), t("12:00"))).toBe("12 AM – 12 PM");
+  });
+
+  it("returns null when a time is missing", () => {
+    expect(formatTimeRange(null, t("17:00"))).toBeNull();
+    expect(formatTimeRange(t("09:00"), undefined)).toBeNull();
+  });
+});
+
+describe("getOpenStatus", () => {
+  const days = "Mon,Tue,Wed,Thu,Fri";
+
+  it("is open during business hours on a listed day", () => {
+    const status = getOpenStatus(days, t("09:00"), t("17:00"), nyNow("2026-07-06 10:00"));
+    expect(status).toEqual({ isOpen: true, label: "Open · Closes 5 PM" });
+  });
+
+  it("is closed outside business hours", () => {
+    const status = getOpenStatus(days, t("09:00"), t("17:00"), nyNow("2026-07-06 18:00"));
+    expect(status).toEqual({ isOpen: false, label: "Closed · Opens 9 AM" });
+  });
+
+  it("is closed on a day that is not listed", () => {
+    // 2026-07-05 is a Sunday
+    const status = getOpenStatus(days, t("09:00"), t("17:00"), nyNow("2026-07-05 10:00"));
+    expect(status?.isOpen).toBe(false);
+  });
+
+  it("handles overnight hours past midnight", () => {
+    // Open Mon 8 PM – 2 AM; Tue 1 AM should still count as open.
+    const late = getOpenStatus("Mon", t("20:00"), t("02:00"), nyNow("2026-07-07 01:00"));
+    expect(late?.isOpen).toBe(true);
+
+    const afterClose = getOpenStatus("Mon", t("20:00"), t("02:00"), nyNow("2026-07-07 03:00"));
+    expect(afterClose?.isOpen).toBe(false);
+  });
+
+  it("returns null when hours or days are missing", () => {
+    expect(getOpenStatus(null, t("09:00"), t("17:00"))).toBeNull();
+    expect(getOpenStatus(days, null, t("17:00"))).toBeNull();
+  });
+});

--- a/src/app/lib/helpers/formatHours.ts
+++ b/src/app/lib/helpers/formatHours.ts
@@ -1,0 +1,102 @@
+/**
+ * Business-hours helpers.
+ *
+ * Open/close times are stored in the DB as time-of-day only (Postgres
+ * `time` via Prisma `@db.Time`), which Prisma surfaces as a Date pinned to
+ * 1970-01-01 UTC. They represent the resource's local wall-clock hours, so
+ * they must always be read with UTC accessors - never the viewer's locale -
+ * and compared against the current time in New York, where every resource
+ * in this app is located.
+ */
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const RESOURCE_TIMEZONE = "America/New_York";
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+type TimeInput = string | Date | null | undefined;
+
+const toMinutesOfDay = (value: TimeInput): number | null => {
+  if (!value) return null;
+  const parsed = dayjs.utc(value);
+  if (!parsed.isValid()) return null;
+  return parsed.hour() * 60 + parsed.minute();
+};
+
+const formatMinutes = (minutes: number): string => {
+  const hour24 = Math.floor(minutes / 60);
+  const minute = minutes % 60;
+  const suffix = hour24 >= 12 ? "PM" : "AM";
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  return minute === 0
+    ? `${hour12} ${suffix}`
+    : `${hour12}:${String(minute).padStart(2, "0")} ${suffix}`;
+};
+
+/** "9 AM – 5:30 PM", or null when either time is missing/invalid. */
+export function formatTimeRange(
+  openTime: TimeInput,
+  closeTime: TimeInput
+): string | null {
+  const open = toMinutesOfDay(openTime);
+  const close = toMinutesOfDay(closeTime);
+  if (open === null || close === null) return null;
+  return `${formatMinutes(open)} – ${formatMinutes(close)}`;
+}
+
+const parseOpenDays = (openDays: string | null | undefined): Set<string> => {
+  if (!openDays) return new Set();
+  return new Set(
+    openDays
+      .split(",")
+      .map((d) => d.trim().slice(0, 3))
+      .filter((d) => DAY_NAMES.includes(d))
+  );
+};
+
+export interface OpenStatus {
+  isOpen: boolean;
+  /** e.g. "Open · Closes 5 PM" or "Closed · Opens 9 AM" */
+  label: string;
+}
+
+/**
+ * Whether the resource is open right now (New York time). Returns null when
+ * hours or days aren't specified - we don't guess and claim "Closed" for a
+ * resource that simply hasn't provided its schedule.
+ */
+export function getOpenStatus(
+  openDays: string | null | undefined,
+  openTime: TimeInput,
+  closeTime: TimeInput,
+  now: dayjs.Dayjs = dayjs()
+): OpenStatus | null {
+  const open = toMinutesOfDay(openTime);
+  const close = toMinutesOfDay(closeTime);
+  const days = parseOpenDays(openDays);
+  if (open === null || close === null || days.size === 0) return null;
+
+  const local = now.tz(RESOURCE_TIMEZONE);
+  const nowMinutes = local.hour() * 60 + local.minute();
+  const today = DAY_NAMES[local.day()];
+  const yesterday = DAY_NAMES[(local.day() + 6) % 7];
+
+  let isOpen: boolean;
+  if (close > open) {
+    isOpen = days.has(today) && nowMinutes >= open && nowMinutes < close;
+  } else {
+    // Overnight hours (e.g. 8 PM – 2 AM): open late on a listed day, or in
+    // the early morning following one.
+    isOpen =
+      (days.has(today) && nowMinutes >= open) ||
+      (days.has(yesterday) && nowMinutes < close);
+  }
+
+  return isOpen
+    ? { isOpen, label: `Open · Closes ${formatMinutes(close)}` }
+    : { isOpen, label: `Closed · Opens ${formatMinutes(open)}` };
+}

--- a/src/app/lib/helpers/mailer.ts
+++ b/src/app/lib/helpers/mailer.ts
@@ -1,5 +1,5 @@
 import { Resend } from 'resend';
-import bcryptjs from 'bcryptjs';
+import crypto from 'crypto';
 // import nodemailer from 'nodemailer';
 import { PrismaClient } from '@prisma/client';
 
@@ -19,10 +19,13 @@ interface sendEmailParams {
 // use case: send email for verify token, forgot pw
 export const sendEmail = async ({ email, emailType, userId }: sendEmailParams) => {
     try {
-        // create a hashed token using userId
-        const hashedToken = await bcryptjs.hash(userId.toString(), 10)
+        // Generate a cryptographically random token. Only its SHA-256 hash is
+        // persisted, so a database leak alone can't be used to reset an account -
+        // the raw token (sent only in the email link) is required.
+        const rawToken = crypto.randomBytes(32).toString('hex')
+        const hashedToken = crypto.createHash('sha256').update(rawToken).digest('hex')
 
-        // update db with token field we created for forgotPasswordToken etc. check schema 
+        // update db with token field we created for forgotPasswordToken etc. check schema
         //token update for verifyToken
         if (emailType === "VERIFY") {
             await prisma.user.update({
@@ -41,11 +44,9 @@ export const sendEmail = async ({ email, emailType, userId }: sendEmailParams) =
                 }
             });
         }
-        
+
         const domain = process.env.DOMAIN ;
-        const resetLink = `${domain}/${emailType === "VERIFY" ? "verifyemail" : "reset-password"}?token=${hashedToken}`;
-        
-        console.log('Attempting to send email with link:', resetLink);
+        const resetLink = `${domain}/${emailType === "VERIFY" ? "verifyemail" : "reset-password"}?token=${rawToken}`;
 
         // =============== NODEMAILER IMPLEMENTATION (FOR REFERENCE) ===============
         /*

--- a/src/app/lib/rate-limit.ts
+++ b/src/app/lib/rate-limit.ts
@@ -28,6 +28,23 @@ const ratelimit = !isDevelopment
     })
   : null;
 
+// Extract the client IP from request headers. The first hop of X-Forwarded-For
+// is whatever the client sent and can be spoofed, so prefer x-real-ip / the
+// platform-appended x-vercel-proxied-for, falling back to the *last* hop of
+// X-Forwarded-For (appended by our own proxy, not attacker-controlled).
+export function getClientIp(headersLike: { get(name: string): string | null }): string {
+  const trusted = headersLike.get('x-real-ip') || headersLike.get('x-vercel-proxied-for');
+  if (trusted) return trusted;
+
+  const forwardedFor = headersLike.get('x-forwarded-for');
+  if (forwardedFor) {
+    const ips = forwardedFor.split(',').map((ip) => ip.trim()).filter(Boolean);
+    if (ips.length > 0) return ips[ips.length - 1];
+  }
+
+  return 'unknown';
+}
+
 // Create a function that checks the rate limit for a given IP
 export async function checkRateLimit(ip: string) {
   // Skip rate limiting in development

--- a/src/app/lib/rate-limit.ts
+++ b/src/app/lib/rate-limit.ts
@@ -56,23 +56,12 @@ export async function checkRateLimit(ip: string) {
         }
       )
     }
-    // do expensive calculation
-    return NextResponse.json({message:"Request successful"})
+    // Within limits: return null so the caller proceeds with its own logic.
+    return null
   } catch (error) {
     console.error('Rate limit error:', error)
     // If rate limiting fails, we should allow the request to proceed
     // rather than blocking legitimate traffic
     return null
   }
-} 
-
-// handler definition
-/**
- * export default async function handler(req, res) {
-  const { success } = await rateLimit.limit(req.ip);
-  if (!success) {
-    return res.status(429).json('Too many requests');
-  }
-  res.status(200).json({ message: 'Request successful' });
 }
- */

--- a/src/app/lib/resources/getResources.ts
+++ b/src/app/lib/resources/getResources.ts
@@ -47,7 +47,24 @@ const getCachedResources = unstable_cache(
     const GROUPS_PER_PAGE = 6;
     const skip = (page - 1) * GROUPS_PER_PAGE; // offset
     try {
-      const search = query.trim();
+      // Split the query into terms and require every term to match at least
+      // one field, so "health queens" finds health resources in Queens
+      // instead of requiring the whole phrase inside a single field.
+      const searchTerms = query.trim().split(/\s+/).filter(Boolean).slice(0, 6);
+      const matchTerm = (term: string) => ({
+        OR: [
+          { name: { contains: term, mode: "insensitive" as const } },
+          { city: { contains: term, mode: "insensitive" as const } },
+          { address: { contains: term, mode: "insensitive" as const } },
+          { description: { contains: term, mode: "insensitive" as const } },
+          {
+            ResourceCategory: {
+              name: { contains: term, mode: "insensitive" as const },
+            },
+          },
+        ],
+      });
+
       // Build where clause based on filters
       const where = {
         ...(categories && categories.length > 0 && {
@@ -62,13 +79,8 @@ const getCachedResources = unstable_cache(
             in: boroughs,
           },
         }),
-        ...(search && {
-          OR: [
-            { name: { contains: search, mode: "insensitive" as const } },
-            { city: { contains: search, mode: "insensitive" as const } },
-            { address: { contains: search, mode: "insensitive" as const } },
-            { description: { contains: search, mode: "insensitive" as const } },
-          ],
+        ...(searchTerms.length > 0 && {
+          AND: searchTerms.map(matchTerm),
         }),
         status: ResourceStatus.APPROVED, // Only show approved resources
       };

--- a/src/app/lib/resources/updateResourceStatus.ts
+++ b/src/app/lib/resources/updateResourceStatus.ts
@@ -1,8 +1,8 @@
 'use server';
 import { revalidatePath } from 'next/cache';
 import { prisma } from '@/app/lib/prisma';
-import { ResourceStatus, Resource } from '@prisma/client';
-// import { v2 as cloudinary } from 'cloudinary';
+import { ResourceStatus, Resource, Role } from '@prisma/client';
+import { getSession } from '@/app/lib/auth-session';
 
 type ResourceUpdateData = Partial<Pick<Resource, 'name' | 'address' | 'phone' | 'url' | 'openDays' | 'openTime' | 'closeTime'>>;
 
@@ -14,6 +14,14 @@ export async function updateResourceStatus(
   resourceType: 'new' | 'edit'
 ) {
   try {
+    // Server actions are callable by any client as POST endpoints, so the
+    // admin check must live here - the dashboard hiding the buttons is not
+    // access control.
+    const session = await getSession();
+    if (!session?.userId || session.role !== Role.ADMIN) {
+      return { success: false, error: "Forbidden" };
+    }
+
     if (!["PENDING", "APPROVED", "REJECTED"].includes(newStatus)) {
       return { success: false, error: "Invalid status" };
     }

--- a/src/app/ui/ResourceDetailCommon/Overview.tsx
+++ b/src/app/ui/ResourceDetailCommon/Overview.tsx
@@ -1,13 +1,13 @@
 import ResourceActions from "./ResourceActions";
 import { formatOpenDays } from "@/app/lib/helpers/formatOpenDays";
+import {
+  formatTimeRange,
+  getOpenStatus,
+} from "@/app/lib/helpers/formatHours";
 import toast from "react-hot-toast";
 
 import { type Resource, User } from "@/app/lib/types";
 import { useRouter } from "next/navigation";
-
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-dayjs.extend(utc);
 
 interface OverviewTabProps {
   resource: Resource;
@@ -25,7 +25,15 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({
   router,
   // liked,
   // toggleFavorite,
-}) => (
+}) => {
+  const hours = formatTimeRange(resource.openTime, resource.closeTime);
+  const openStatus = getOpenStatus(
+    resource.openDays,
+    resource.openTime,
+    resource.closeTime
+  );
+
+  return (
   <div>
     <ResourceActions
       resource={resource}
@@ -42,15 +50,32 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({
     )}
     {resource.openDays && (
       <p>
-        <span className="font-medium">Opens:</span>{" "}
+        <span className="font-medium">Open:</span>{" "}
         {formatOpenDays(resource.openDays || null)}
+        {hours ? `, ${hours}` : ""}
       </p>
     )}
-    {resource.openTime && resource.closeTime && (
+    {!resource.openDays && hours && (
       <p>
-        <span className="font-medium">Business Hours:</span>{" "}
-        {dayjs.utc(resource.openTime).format("hh:mm A")} -{" "}
-        {dayjs.utc(resource.closeTime).format("hh:mm A")}
+        <span className="font-medium">Hours:</span> {hours}
+      </p>
+    )}
+    {openStatus && (
+      <p>
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-semibold ${
+            openStatus.isOpen
+              ? "bg-green-100 text-green-700"
+              : "bg-red-100 text-red-700"
+          }`}
+        >
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${
+              openStatus.isOpen ? "bg-green-600" : "bg-red-600"
+            }`}
+          />
+          {openStatus.label}
+        </span>
       </p>
     )}
     {resource.url && (
@@ -97,4 +122,5 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({
       </button>
     </div>
   </div>
-);
+  );
+};

--- a/src/app/ui/SearchInput.tsx
+++ b/src/app/ui/SearchInput.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
-import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline";
 
 interface SearchInputProps {
   placeholder?: string;
@@ -45,10 +45,18 @@ export default function SearchInput({ placeholder = "Search..." }: SearchInputPr
     return () => clearTimeout(timer);
   }, [localValue, urlQuery, handleSearch]);
 
+  const handleClear = () => {
+    setLocalValue("");
+    handleSearch("");
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       e.preventDefault();
       handleSearch(localValue);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      handleClear();
     }
   };
 
@@ -65,7 +73,9 @@ export default function SearchInput({ placeholder = "Search..." }: SearchInputPr
       </label>
       <input
         id="search"
-        className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
+        type="search"
+        autoComplete="off"
+        className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 pr-9 text-sm outline-2 placeholder:text-gray-500 [&::-webkit-search-cancel-button]:hidden"
         placeholder={placeholder}
         value={localValue}
         onChange={(e) => setLocalValue(e.target.value)}
@@ -73,6 +83,17 @@ export default function SearchInput({ placeholder = "Search..." }: SearchInputPr
         onBlur={handleBlur}
       />
       <MagnifyingGlassIcon className="absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
+      {localValue && (
+        <button
+          type="button"
+          aria-label="Clear search"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={handleClear}
+          className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+        >
+          <XMarkIcon className="h-4 w-4" />
+        </button>
+      )}
     </div>
   );
 }

--- a/src/app/ui/map/Markers.tsx
+++ b/src/app/ui/map/Markers.tsx
@@ -1,6 +1,9 @@
 "use client";
 import Image from "next/image";
-import { getMarkerIconByCategory } from "./utils/markerIcons";
+import {
+  getMarkerIconByCategory,
+  getMarkerColorByCategory,
+} from "./utils/markerIcons";
 import { MarkerClusterer } from "@googlemaps/markerclusterer";
 import {
   AdvancedMarker,
@@ -123,8 +126,11 @@ export const Markers = ({ points, hoveredResourceId }: MarkersProps) => {
         // Show InfoWindow on either hover or click
         const shouldShowInfoWindow = isHighlighted;
 
-        // Get marker icon based on resource category
+        // Get marker icon and pin color based on resource category
         const image = getMarkerIconByCategory(resource.ResourceCategory?.name);
+        const pinColor = getMarkerColorByCategory(
+          resource.ResourceCategory?.name
+        );
 
         return (
           <div
@@ -179,12 +185,8 @@ export const Markers = ({ points, hoveredResourceId }: MarkersProps) => {
                     width: isHighlighted ? 30 : 24,
                     height: isHighlighted ? 30 : 24,
                     borderRadius: "9999px",
-                    background: isHighlighted
-                      ? "rgba(37, 99, 235, 0.16)"
-                      : "rgba(37, 99, 235, 0.08)",
-                    border: isHighlighted
-                      ? "1px solid rgba(37, 99, 235, 0.28)"
-                      : "1px solid rgba(37, 99, 235, 0.12)",
+                    background: `${pinColor.base}${isHighlighted ? "29" : "14"}`,
+                    border: `1px solid ${pinColor.base}${isHighlighted ? "47" : "1f"}`,
                     boxShadow: "0 0 0 3px rgba(255,255,255,0.26)",
                     animation: isHighlighted
                       ? "marker-pulse 1.6s ease-out infinite"
@@ -202,17 +204,17 @@ export const Markers = ({ points, hoveredResourceId }: MarkersProps) => {
                     height: isHighlighted ? 24 : 20,
                     borderRadius: "9999px",
                     background: isHighlighted
-                      ? "#2563eb"
-                      : "#3b82f6",
+                      ? pinColor.highlight
+                      : pinColor.base,
                     border: "2px solid #ffffff",
                     boxShadow: isHighlighted
-                      ? "0 6px 12px rgba(37, 99, 235, 0.24)"
+                      ? "0 6px 12px rgba(15, 23, 42, 0.28)"
                       : "0 3px 8px rgba(15, 23, 42, 0.20)",
                   }}
                 >
                   <Image
                     src={image}
-                    alt={`${resource.ResourceCategory?.name} icon`}
+                    alt={`${resource.ResourceCategory?.name || "Resource"} icon`}
                     style={{
                       objectFit: "contain",
                       backgroundColor: "transparent",
@@ -232,11 +234,30 @@ export const Markers = ({ points, hoveredResourceId }: MarkersProps) => {
                     borderLeft: "5px solid transparent",
                     borderRight: "5px solid transparent",
                     borderTop: isHighlighted
-                      ? "10px solid #2563eb"
-                      : "9px solid #3b82f6",
+                      ? `10px solid ${pinColor.highlight}`
+                      : `9px solid ${pinColor.base}`,
                     filter: "drop-shadow(0 2px 3px rgba(15, 23, 42, 0.16))",
                   }}
                 />
+                {/* Name label under the pin, like native map POI labels */}
+                <span
+                  style={{
+                    marginTop: 2,
+                    maxWidth: 120,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    fontSize: 11,
+                    fontWeight: 600,
+                    lineHeight: "14px",
+                    color: isHighlighted ? pinColor.highlight : "#1e293b",
+                    textShadow:
+                      "0 1px 0 #fff, 0 -1px 0 #fff, 1px 0 0 #fff, -1px 0 0 #fff, 0 0 4px #fff",
+                    pointerEvents: "none",
+                  }}
+                >
+                  {resource.name}
+                </span>
               </div>
             </AdvancedMarker>
 

--- a/src/app/ui/map/utils/markerIcons.ts
+++ b/src/app/ui/map/utils/markerIcons.ts
@@ -1,7 +1,7 @@
 // Map of resource categories to their corresponding icon URLs
 export const getMarkerIconByCategory = (category?: string): string => {
   const defaultIcon = "https://cdn-icons-png.flaticon.com/512/1946/1946436.png";
-  
+
   if (!category) return defaultIcon;
 
   const iconMap: Record<string, string> = {
@@ -16,4 +16,28 @@ export const getMarkerIconByCategory = (category?: string): string => {
   };
 
   return iconMap[category.toLowerCase()] || defaultIcon;
+};
+
+// Per-category pin colors so markers are distinguishable at a glance.
+// Each entry has a base color and a darker shade used for hover/highlight.
+export const getMarkerColorByCategory = (
+  category?: string
+): { base: string; highlight: string } => {
+  const colorMap: Record<string, { base: string; highlight: string }> = {
+    community: { base: "#8b5cf6", highlight: "#7c3aed" }, // violet
+    legal: { base: "#0ea5e9", highlight: "#0284c7" }, // sky blue
+    health: { base: "#ef4444", highlight: "#dc2626" }, // red
+    education: { base: "#f59e0b", highlight: "#d97706" }, // amber
+    finance: { base: "#10b981", highlight: "#059669" }, // emerald
+    "real estate": { base: "#ec4899", highlight: "#db2777" }, // pink
+    business: { base: "#14b8a6", highlight: "#0d9488" }, // teal
+    other: { base: "#64748b", highlight: "#475569" }, // slate
+  };
+
+  return (
+    colorMap[category?.toLowerCase() ?? ""] ?? {
+      base: "#3b82f6",
+      highlight: "#2563eb",
+    }
+  );
 };

--- a/src/app/ui/resources/ResourceCard.tsx
+++ b/src/app/ui/resources/ResourceCard.tsx
@@ -10,10 +10,10 @@
 // need to research if i can import simply Resource type from prisma
 
 import { type Resource } from "@/app/lib/types";
-// import { formatOpenDays } from "@/app/lib/helpers/formatOpenDays";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-dayjs.extend(utc);
+import {
+  formatTimeRange,
+  getOpenStatus,
+} from "@/app/lib/helpers/formatHours";
 
 interface ResourceCardProps {
   resources: Resource[];
@@ -30,7 +30,15 @@ export default function ResourceCard({
     <div className="flex flex-col  justify-between space-y-4 pb-20">
       {resources
         .filter((resource) => resource.status === "APPROVED")
-        .map((resource) => (
+        .map((resource) => {
+          const hours = formatTimeRange(resource.openTime, resource.closeTime);
+          const openStatus = getOpenStatus(
+            resource.openDays,
+            resource.openTime,
+            resource.closeTime
+          );
+
+          return (
           <div
             key={resource.id}
             className="flex flex-col md:flex-row space-y-4 justify-between p-4 border rounded-md shadow-md bg-white transition-all duration-300 hover:shadow-xl hover:-translate-y-1 hover:scale-[1.02]"
@@ -51,6 +59,29 @@ export default function ResourceCard({
                 <strong>Address: </strong>
                 {resource.address ? resource.address : "No address available"}
               </p>
+              {(openStatus || hours) && (
+                <p className="mt-1 flex flex-wrap items-center gap-2">
+                  {openStatus && (
+                    <span
+                      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-semibold ${
+                        openStatus.isOpen
+                          ? "bg-green-100 text-green-700"
+                          : "bg-red-100 text-red-700"
+                      }`}
+                    >
+                      <span
+                        className={`h-1.5 w-1.5 rounded-full ${
+                          openStatus.isOpen ? "bg-green-600" : "bg-red-600"
+                        }`}
+                      />
+                      {openStatus.label}
+                    </span>
+                  )}
+                  {!openStatus && hours && (
+                    <span className="text-sm text-gray-600">{hours}</span>
+                  )}
+                </p>
+              )}
             </div>
 
             <div className="flex items-end ml-4">
@@ -60,10 +91,11 @@ export default function ResourceCard({
               >
                 View Details
               </button>
-              
+
             </div>
           </div>
-        ))}
+          );
+        })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

### Security fixes (full-codebase review)

- **Sensitive data exposure**: `/api/auth/forgotpassword` and the `forgotPassword` server action returned the full unselected `User` record (password hash, reset/verify tokens, role) to any unauthenticated caller. Now returns a generic success message and no longer reveals whether an account exists.
- **Broken access control**: `PATCH /api/resources/edit/[id]` had no auth check — anyone could approve/reject edit suggestions. Now admin-only. Same fix applied to the `updateResourceStatus` server action, which also had no auth check (server actions are public POST endpoints).
- **Unauthenticated Cloudinary abuse**: `/api/sign-image` signed arbitrary caller-supplied params with the server's API secret and `/api/upload` accepted uploads with no auth. Both now require a session; `sign-image` rejects dangerous params (`public_id`, `overwrite`, etc.) and array payloads.
- **Weak reset/verify tokens**: tokens were `bcrypt(userId)` with the same value stored in the DB and emailed. Now `crypto.randomBytes(32)` with only the SHA-256 hash stored; email sending is deferred via `after()` so response timing doesn't leak account existence.
- **Cron fail-open**: `/api/cron` accepted `Bearer undefined` when `CRON_SECRET` was unset. Now fails closed and uses a timing-safe comparison.
- **Rate limiter bug**: `checkRateLimit` returned a truthy response on the *allowed* path, short-circuiting every caller. Fixed; also added rate limiting to `login`/`forgotPassword`, a spoof-resistant `getClientIp` helper (trusted headers, last XFF hop), and a timing-safe dummy bcrypt compare for unknown logins with a unified error message.
- **Mass assignment**: `POST /api/resources` spread the raw body into `prisma.resource.create()`; now whitelists submitter-controlled fields and validates `name`/`address`/`categoryId`.
- **CI**: the CodeQL workflow build was failing on missing `JWT_SECRET` (thrown at import time); it now injects the secret with a build-only fallback.

### Search

- Queries are tokenized and terms are AND-ed, each matching name/city/address/description/**category**, so "health queens" finds health resources in Queens instead of requiring the whole phrase in a single field.
- Search input gets a clear (×) button and Escape-to-clear.

### Map labels

- Pins are color-coded by category (violet community, red health, amber education, etc.) with matching hover/highlight shades.
- Each pin shows the resource name beneath it with a white halo, like native map POI labels.

### Business hours (best practice)

- New `formatHours` helper: `formatTimeRange` renders the stored time-of-day columns as "9 AM – 5:30 PM", and `getOpenStatus` computes open/closed **in America/New_York**, handles overnight ranges, and returns null instead of guessing when hours aren't provided. Covered by unit tests.
- Detail overview and list cards show hours plus a green/red "Open · Closes 5 PM" / "Closed · Opens 9 AM" badge.

### Seed resources

- Added The Tibet Fund, Tibet House US, Queens Public Library – Woodside, and NYC Health + Hospitals/Elmhurst, all with open days/hours; gave the Consulate General of Nepal entry hours too.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `next lint` — no warnings/errors
- [x] `npx jest` — new `formatHours` suite (8 tests) passes; remaining failures are the pre-existing missing-module/Playwright-config baseline
- [ ] Manual verification on the preview deploy: search terms, colored/labelled map pins, Open/Closed badges, admin approval flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsdtBWuB5qnmJkQbB7ihLk